### PR TITLE
Fix: label extraction with airplane mode

### DIFF
--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -1,11 +1,11 @@
 import { ElementType } from "@/components/workspace/elements";
-import { dataAttributes, selectors } from "@/constants";
+import { dataAttributes } from "@/constants";
 import { store } from "@/store";
 import { ISTKData, ISeat } from "@/types";
 import { rgbToHex } from ".";
 import { default as d3Extended } from "./d3";
 
-export const domSeatsToJSON = (seats: ISeat[]) => {
+const domSeatsToJSON = (seats: ISeat[]) => {
   return d3Extended.selectAll(`[${dataAttributes.elementType}="${ElementType.Seat}"]`).map((seat) => {
     const id = seat.attr("id");
     const square = (seat.node() as any)?.nodeName === "rect";
@@ -23,7 +23,7 @@ export const domSeatsToJSON = (seats: ISeat[]) => {
   });
 };
 
-export const domTextToJSON = () => {
+const domTextToJSON = () => {
   return d3Extended.selectAll(`[${dataAttributes.elementType}="${ElementType.Text}"]`).map((text) => {
     return {
       id: text.attr("id"),
@@ -40,7 +40,7 @@ export const domTextToJSON = () => {
   });
 };
 
-export const domShapesToJSON = () => {
+const domShapesToJSON = () => {
   return d3Extended.selectAll(`[${dataAttributes.elementType}="${ElementType.Shape}"]`).map((shape) => {
     return {
       id: shape.attr("id"),
@@ -57,7 +57,7 @@ export const domShapesToJSON = () => {
   });
 };
 
-export const domPolylineToJSON = () => {
+const domPolylineToJSON = () => {
   return d3Extended
     .selectAll(`[${dataAttributes.elementType}="${ElementType.Polyline}"]`)
     .map((polyline) => {
@@ -79,7 +79,7 @@ export const domPolylineToJSON = () => {
     .filter((polyline) => polyline.points.length > 1);
 };
 
-export const domImagesToJSON = () => {
+const domImagesToJSON = () => {
   return d3Extended.selectAll(`[${dataAttributes.elementType}="${ElementType.Image}"]`).map((image) => {
     return {
       id: image.attr("id"),
@@ -92,10 +92,6 @@ export const domImagesToJSON = () => {
       locked: image.attr(dataAttributes.objectLock) === "true"
     };
   });
-};
-
-export const domTransform = () => {
-  return d3Extended.zoomTransform(document.querySelector(selectors.workspaceGroup));
 };
 
 export const stateToJSON = (): ISTKData => {

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -6,15 +6,18 @@ import { rgbToHex } from ".";
 import { default as d3Extended } from "./d3";
 
 const domSeatsToJSON = (seats: ISeat[]) => {
+  const seatsFromStore: Record<string, ISeat> = seats.reduce((acc, seat) => {
+    acc[seat.id] = seat;
+    return acc;
+  }, {});
   return d3Extended.selectAll(`[${dataAttributes.elementType}="${ElementType.Seat}"]`).map((seat) => {
     const id = seat.attr("id");
     const square = (seat.node() as any)?.nodeName === "rect";
-    const seatFromStore = seats.find((s) => s.id === id);
     return {
       id,
       x: +seat.attr(square ? "x" : "cx"),
       y: +seat.attr(square ? "y" : "cy"),
-      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent ?? seatFromStore?.label,
+      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent?.trim() || seatsFromStore[id]?.label,
       status: seat.attr(dataAttributes.status),
       category: seat.attr(dataAttributes.category),
       square,

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -5,8 +5,8 @@ import { ISTKData, ISeat } from "@/types";
 import { rgbToHex } from ".";
 import { default as d3Extended } from "./d3";
 
-const domSeatsToJSON = (seats: ISeat[]) => {
-  const seatsFromStore: Record<string, ISeat> = seats.reduce((acc, seat) => {
+const domSeatsToJSON = (seatsFromStore: ISeat[] | Record<string, ISeat>) => {
+  seatsFromStore = (seatsFromStore as ISeat[]).reduce((acc, seat) => {
     acc[seat.id] = seat;
     return acc;
   }, {});
@@ -17,7 +17,8 @@ const domSeatsToJSON = (seats: ISeat[]) => {
       id,
       x: +seat.attr(square ? "x" : "cx"),
       y: +seat.attr(square ? "y" : "cy"),
-      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent?.trim() ?? seatsFromStore[id]?.label,
+      label:
+        document.getElementById(`${seat.attr("id")}-label`)?.textContent?.trim() ?? seatsFromStore[id]?.label?.trim(),
       status: seat.attr(dataAttributes.status),
       category: seat.attr(dataAttributes.category),
       square,

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -17,7 +17,7 @@ const domSeatsToJSON = (seats: ISeat[]) => {
       id,
       x: +seat.attr(square ? "x" : "cx"),
       y: +seat.attr(square ? "y" : "cy"),
-      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent?.trim() || seatsFromStore[id]?.label,
+      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent?.trim() ?? seatsFromStore[id]?.label,
       status: seat.attr(dataAttributes.status),
       category: seat.attr(dataAttributes.category),
       square,

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -1,18 +1,20 @@
 import { ElementType } from "@/components/workspace/elements";
 import { dataAttributes, selectors } from "@/constants";
 import { store } from "@/store";
-import { ISTKData } from "@/types";
+import { ISTKData, ISeat } from "@/types";
 import { rgbToHex } from ".";
 import { default as d3Extended } from "./d3";
 
-export const domSeatsToJSON = () => {
+export const domSeatsToJSON = (seats: ISeat[]) => {
   return d3Extended.selectAll(`[${dataAttributes.elementType}="${ElementType.Seat}"]`).map((seat) => {
+    const id = seat.attr("id");
     const square = (seat.node() as any)?.nodeName === "rect";
+    const seatFromStore = seats.find((s) => s.id === id);
     return {
-      id: seat.attr("id"),
+      id,
       x: +seat.attr(square ? "x" : "cx"),
       y: +seat.attr(square ? "y" : "cy"),
-      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent,
+      label: document.getElementById(`${seat.attr("id")}-label`)?.textContent ?? seatFromStore?.label,
       status: seat.attr(dataAttributes.status),
       category: seat.attr(dataAttributes.category),
       square,
@@ -102,7 +104,7 @@ export const stateToJSON = (): ISTKData => {
     name: state.location,
     categories: state.categories.slice(1),
     sections: state.sections.slice(1),
-    seats: domSeatsToJSON(),
+    seats: domSeatsToJSON(state.seats),
     text: domTextToJSON(),
     shapes: domShapesToJSON(),
     polylines: domPolylineToJSON(),


### PR DESCRIPTION
## Summary by Sourcery

Fix seat label extraction when DOM labels are missing, refactor transformer functions, and cleanup unused exports and imports

Bug Fixes:
- Fallback to stored seat labels when DOM label text is empty or unavailable

Enhancements:
- Make domSeatsToJSON accept the seats array and use it for label fallback
- Update stateToJSON to pass state.seats into domSeatsToJSON

Chores:
- Remove unused selectors import and domTransform export
- Internalize text, shapes, polyline, and image transformer functions by removing their exports